### PR TITLE
art details [DATA]

### DIFF
--- a/app/src/main/java/com/novack/art_gallery/art_details/domain/models/ArtworkDetails.kt
+++ b/app/src/main/java/com/novack/art_gallery/art_details/domain/models/ArtworkDetails.kt
@@ -1,0 +1,10 @@
+package com.novack.art_gallery.art_details.domain.models
+
+data class ArtworkDetails(
+    val id: String,
+    val title: String?,
+    val description: String?,
+    val date: String?,
+    val artist: String?,
+    val imageUrl: String,
+)

--- a/app/src/main/java/com/novack/art_gallery/common/data/ArtRepository.kt
+++ b/app/src/main/java/com/novack/art_gallery/common/data/ArtRepository.kt
@@ -1,8 +1,11 @@
 package com.novack.art_gallery.common.data
 
+import com.novack.art_gallery.art_details.domain.models.ArtworkDetails
 import com.novack.art_gallery.art_overview.domain.models.ArtworkOverview
 
 interface ArtRepository {
 
     suspend fun getArtworksOverview(): List<ArtworkOverview>
+
+    suspend fun getArtworkDetails(id: String): ArtworkDetails
 }

--- a/app/src/main/java/com/novack/art_gallery/common/data/NetworkDataSource.kt
+++ b/app/src/main/java/com/novack/art_gallery/common/data/NetworkDataSource.kt
@@ -1,7 +1,10 @@
 package com.novack.art_gallery.common.data
 
+import com.novack.art_gallery.common.data.model.ArtworkDetailsDTO
 import com.novack.art_gallery.common.data.model.OverviewResponseDTO
 
 interface NetworkDataSource {
     suspend fun getArtworksOverview(): OverviewResponseDTO
+
+    suspend fun getArtworkDetails(id: String): ArtworkDetailsDTO
 }

--- a/app/src/main/java/com/novack/art_gallery/common/data/OnlineRepository.kt
+++ b/app/src/main/java/com/novack/art_gallery/common/data/OnlineRepository.kt
@@ -15,4 +15,7 @@ class OnlineRepository @Inject constructor(
         api.getArtworksOverview().toDomain()
     }
 
+    override suspend fun getArtworkDetails(id: String) = withContext(dispatcher) {
+        api.getArtworkDetails(id).toDomain()
+    }
 }

--- a/app/src/main/java/com/novack/art_gallery/common/data/mappers/ArtworkDetailsToDomain.kt
+++ b/app/src/main/java/com/novack/art_gallery/common/data/mappers/ArtworkDetailsToDomain.kt
@@ -1,0 +1,17 @@
+package com.novack.art_gallery.common.data.mappers
+
+import com.novack.art_gallery.art_details.domain.models.ArtworkDetails
+import com.novack.art_gallery.common.data.model.ArtworkDetailsDTO
+import com.novack.art_gallery.common.data.model.ArtworkDetailsDataDTO
+
+
+internal fun ArtworkDetailsDTO.toDomain() = data.toDomain()
+
+private fun ArtworkDetailsDataDTO.toDomain() = ArtworkDetails(
+    id = id.toString(),
+    title = title,
+    description = description,
+    date = date,
+    artist = artist,
+    imageUrl = "$iiifImageBaseUrl$imageId$imageSize",
+)

--- a/app/src/main/java/com/novack/art_gallery/common/data/mappers/ArtworksOverviewToDomain.kt
+++ b/app/src/main/java/com/novack/art_gallery/common/data/mappers/ArtworksOverviewToDomain.kt
@@ -4,8 +4,8 @@ import com.novack.art_gallery.art_overview.domain.models.ArtworkOverview
 import com.novack.art_gallery.common.data.model.OverviewDataDTO
 import com.novack.art_gallery.common.data.model.OverviewResponseDTO
 
-private const val iiifImageBaseUrl = "https://www.artic.edu/iiif/2/"
-private const val imageSize = "/full/843,/0/default.jpg"
+internal const val iiifImageBaseUrl = "https://www.artic.edu/iiif/2/"
+internal const val imageSize = "/full/843,/0/default.jpg"
 
 internal fun OverviewResponseDTO.toDomain() = data.filter { it.imageId != null}.map {
     it.toDomain()

--- a/app/src/main/java/com/novack/art_gallery/common/data/model/ArtworkDetailsDTO.kt
+++ b/app/src/main/java/com/novack/art_gallery/common/data/model/ArtworkDetailsDTO.kt
@@ -1,0 +1,19 @@
+package com.novack.art_gallery.common.data.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ArtworkDetailsDTO(
+    val data: ArtworkDetailsDataDTO,
+)
+
+@JsonClass(generateAdapter = true)
+data class ArtworkDetailsDataDTO(
+    val id: Int,
+    val title: String?,
+    val description: String?,
+    val date: String?,
+    val artist: String?,
+    @Json(name = "image_id") val imageId: String?,
+)

--- a/app/src/main/java/com/novack/art_gallery/common/data/retrofit/RetrofitNetwork.kt
+++ b/app/src/main/java/com/novack/art_gallery/common/data/retrofit/RetrofitNetwork.kt
@@ -1,10 +1,12 @@
 package com.novack.art_gallery.common.data.retrofit
 
 import com.novack.art_gallery.common.data.NetworkDataSource
+import com.novack.art_gallery.common.data.model.ArtworkDetailsDTO
 import com.novack.art_gallery.common.data.model.OverviewResponseDTO
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.http.GET
+import retrofit2.http.Path
 import retrofit2.http.Query
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -17,6 +19,11 @@ private interface RetrofitNetworkApi {
     suspend fun getArtworksOverview(
         @Query("limit") limit: String = "10",
     ): OverviewResponseDTO
+
+    @GET(value = "artworks/{id}")
+    suspend fun getArtworkDetails(
+        @Path("id") id: String,
+    ): ArtworkDetailsDTO
 
 }
 
@@ -31,6 +38,9 @@ class RetrofitNetwork @Inject constructor() : NetworkDataSource {
 
     override suspend fun getArtworksOverview(): OverviewResponseDTO =
         networkApi.getArtworksOverview()
+
+    override suspend fun getArtworkDetails(id: String): ArtworkDetailsDTO =
+        networkApi.getArtworkDetails(id)
 
 }
 

--- a/app/src/test/java/com/novack/art_gallery/common/data/OnlineRepositoryTest.kt
+++ b/app/src/test/java/com/novack/art_gallery/common/data/OnlineRepositoryTest.kt
@@ -1,6 +1,8 @@
 package com.novack.art_gallery.common.data
 
 import com.novack.art_gallery.common.data.mappers.toDomain
+import com.novack.art_gallery.common.data.model.ArtworkDetailsDTO
+import com.novack.art_gallery.common.data.model.ArtworkDetailsDataDTO
 import com.novack.art_gallery.common.data.model.OverviewDataDTO
 import com.novack.art_gallery.common.data.model.OverviewResponseDTO
 import com.novack.art_gallery.common.data.retrofit.RetrofitNetwork
@@ -29,7 +31,7 @@ class OnlineRepositoryTest {
 
     @Test
     fun `getArtworksOverview successful response`() = runTest(testDispatcher) {
-        // Arrange
+        // given
         val fakeArtworksDTO = OverviewResponseDTO(
             data = listOf(
                 OverviewDataDTO(
@@ -49,32 +51,64 @@ class OnlineRepositoryTest {
         val expectedArtworks = fakeArtworksDTO.data.map { it.toDomain() }
         coEvery { retrofitNetwork.getArtworksOverview() } returns fakeArtworksDTO
 
-        // Act
+        // when
         val result = repository.getArtworksOverview()
 
-        // Assert
+        // then
         assertEquals(expectedArtworks, result)
     }
 
     @Test
     fun `getArtworksOverview empty list response`() = runTest(testDispatcher) {
-        // Arrange
+        // given
         val fakeEmptyDTO = OverviewResponseDTO(data = emptyList())
         coEvery { retrofitNetwork.getArtworksOverview() } returns fakeEmptyDTO
 
-        // Act
+        // when
         val result = repository.getArtworksOverview()
 
-        // Assert
+        // then
         assert(result.isEmpty())
     }
 
     @Test(expected = IOException::class)
     fun `getArtworksOverview API error handling`() = runTest(testDispatcher) {
-        // Arrange
+        // given
         coEvery { retrofitNetwork.getArtworksOverview() } throws IOException("Network error")
 
-        // Act
+        // then
         repository.getArtworksOverview()
+    }
+
+    @Test
+    fun `getArtworkDetails successful response`() = runTest(testDispatcher) {
+        // given
+        val fakeArtworkDetailsDTO = ArtworkDetailsDTO(
+            data = ArtworkDetailsDataDTO(
+                id = 1,
+                title = "Mona Lisa",
+                description = "Iconic portrait of Lisa Gherardini",
+                date = "1503-15",
+                artist = "Leonardo da Vinci",
+                imageId = "id1"
+            )
+            )
+        val expectedArtwork = fakeArtworkDetailsDTO.toDomain()
+        coEvery { retrofitNetwork.getArtworkDetails("1")} returns fakeArtworkDetailsDTO
+
+        // when
+        val result = repository.getArtworkDetails("1")
+
+        // then
+        assertEquals(expectedArtwork, result)
+    }
+
+    @Test(expected = IOException::class)
+    fun `getArtworkDetails API error handling`() = runTest(testDispatcher) {
+        // given
+        coEvery { retrofitNetwork.getArtworkDetails(any()) } throws IOException("Network error")
+
+        // then
+        repository.getArtworkDetails("1")
     }
 }


### PR DESCRIPTION
feat: art details DATA

Added functionality to fetch detailed information
for a specific artwork.

Key changes include:
- Added data models for ArtworkDetailsDTO and ArtworkDetails.
- Implemented mappers to convert DTOs to domain models.
- Updated NetworkDataSource and RetrofitNetwork to include a method for fetching artwork details by ID.
- Updated ArtRepository and OnlineRepository to support fetching artwork details.
- Added unit tests for the new repository functionality.
- Made `iiifImageBaseUrl` and `imageSize` in `ArtworksOverviewToDomain.kt` internal to be reused in `ArtworkDetailsToDomain.kt`.