### PR TITLE
art details [WIRING]

### DIFF
--- a/app/src/main/java/com/novack/art_gallery/MainActivity.kt
+++ b/app/src/main/java/com/novack/art_gallery/MainActivity.kt
@@ -13,6 +13,9 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.novack.art_gallery.art_details.ui.ArtDetailsScreen
+import com.novack.art_gallery.art_details.ui.ArtworkDetailsViewModel
+import com.novack.art_gallery.art_details.ui.mappers.toParam
 import com.novack.art_gallery.art_overview.ui.ArtOverviewScreen
 import com.novack.art_gallery.art_overview.ui.ArtworkOverviewViewModel
 import com.novack.art_gallery.art_overview.ui.mappers.toParam
@@ -38,18 +41,25 @@ class MainActivity : ComponentActivity() {
 
                         ArtOverviewScreen(
                             param = state.toParam(),
-                            onPreviewClick = {},
+                            onPreviewClick = {
+                                navController.navigate(AppScreens.ArtDetails.createRoute(it))
+                            },
                         )
                     }
                     composable(
                         route = AppScreens.ArtDetails.route,
                         arguments = listOf(navArgument("artworkId") {
                             type = NavType.StringType
-                            nullable = true
+                            nullable = false
                         })
                     ) { backStackEntry ->
-                        val artworkId = backStackEntry.arguments?.getString("artworkId")
-                        Text("Art Details Screen. ID: ${artworkId ?: "None"}")
+                        val viewModel: ArtworkDetailsViewModel = hiltViewModel()
+                        val state by viewModel.fetchState.collectAsStateWithLifecycle()
+
+                        ArtDetailsScreen(
+                            param = state.toParam(),
+                            onBackClick = navController::popBackStack
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/novack/art_gallery/art_details/domain/ArtworkDetailsState.kt
+++ b/app/src/main/java/com/novack/art_gallery/art_details/domain/ArtworkDetailsState.kt
@@ -1,0 +1,13 @@
+package com.novack.art_gallery.art_details.domain
+
+import com.novack.art_gallery.art_details.domain.models.ArtworkDetails
+
+sealed interface ArtworkDetailsState {
+    data object Loading : ArtworkDetailsState
+
+    data object Error : ArtworkDetailsState
+
+    data class Loaded(
+        val  artworkDetails: ArtworkDetails,
+    ) : ArtworkDetailsState
+}

--- a/app/src/main/java/com/novack/art_gallery/art_details/domain/GetArtworkDetailsUseCase.kt
+++ b/app/src/main/java/com/novack/art_gallery/art_details/domain/GetArtworkDetailsUseCase.kt
@@ -1,0 +1,28 @@
+package com.novack.art_gallery.art_details.domain
+
+import com.novack.art_gallery.common.data.ArtRepository
+import com.novack.art_gallery.common.domain.Logger
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class GetArtworkDetailsUseCase @Inject constructor(
+    private val repository: ArtRepository,
+    private val logger: Logger,
+) {
+    operator fun invoke(id: String) = flow {
+        emit(ArtworkDetailsState.Loading)
+        try {
+            val artworkDetails = repository.getArtworkDetails(id)
+            emit(ArtworkDetailsState.Loaded(artworkDetails = artworkDetails))
+        } catch (e: Exception) {
+            logger.e("GetArtworkDetailsUseCase", "Error fetching artwork details", e)
+            emit(ArtworkDetailsState.Error)
+
+        }
+    }
+        .catch {
+            logger.e("GetArtworkDetailsUseCase", "Error processing artwork details", it)
+            emit(ArtworkDetailsState.Error)
+        }
+}

--- a/app/src/main/java/com/novack/art_gallery/art_details/ui/ArtworkDetailsViewModel.kt
+++ b/app/src/main/java/com/novack/art_gallery/art_details/ui/ArtworkDetailsViewModel.kt
@@ -1,0 +1,29 @@
+package com.novack.art_gallery.art_details.ui
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.novack.art_gallery.art_details.domain.ArtworkDetailsState
+import com.novack.art_gallery.art_details.domain.GetArtworkDetailsUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class ArtworkDetailsViewModel @Inject constructor(
+    useCase: GetArtworkDetailsUseCase,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val artworkId: String = savedStateHandle.get<String>("artworkId")
+        ?: throw IllegalStateException("artworkId not found in SavedStateHandle")
+
+    val fetchState = useCase(artworkId)
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = ArtworkDetailsState.Loading
+        )
+
+}

--- a/app/src/main/java/com/novack/art_gallery/art_details/ui/mappers/ArtworkDetailsStateToParam.kt
+++ b/app/src/main/java/com/novack/art_gallery/art_details/ui/mappers/ArtworkDetailsStateToParam.kt
@@ -1,0 +1,20 @@
+package com.novack.art_gallery.art_details.ui.mappers
+
+import com.novack.art_gallery.art_details.domain.ArtworkDetailsState
+import com.novack.art_gallery.art_details.ui.ArtDetailsInfoParam
+import com.novack.art_gallery.art_details.ui.ArtDetailsParam
+
+internal fun ArtworkDetailsState.toParam() = when(this) {
+    ArtworkDetailsState.Error -> ArtDetailsParam.Error
+    ArtworkDetailsState.Loading -> ArtDetailsParam.Loading
+    is ArtworkDetailsState.Loaded -> ArtDetailsParam.Loaded(
+        artDetails = ArtDetailsInfoParam(
+            id = artworkDetails.id,
+            artist = artworkDetails.artist,
+            title = artworkDetails.title,
+            imageUrl = artworkDetails.imageUrl,
+            description = artworkDetails.description,
+            date = artworkDetails.date,
+        )
+    )
+}

--- a/app/src/main/java/com/novack/art_gallery/common/data/model/ArtworkDetailsDTO.kt
+++ b/app/src/main/java/com/novack/art_gallery/common/data/model/ArtworkDetailsDTO.kt
@@ -12,8 +12,8 @@ data class ArtworkDetailsDTO(
 data class ArtworkDetailsDataDTO(
     val id: Int,
     val title: String?,
-    val description: String?,
-    val date: String?,
-    val artist: String?,
+    @Json(name = "medium_display")val description: String?,
+    @Json(name = "date_display") val date: String?,
+    @Json(name = "artist_title")val artist: String?,
     @Json(name = "image_id") val imageId: String?,
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,6 @@
     <string name="art_details_description">Description: %s</string>"
     <string name="art_details_date">Date: %s</string>"
     <string name="art_details_artist">Artist: %s</string>"
-    <string name="art_details_no_description">Description: No description available</string>
-    <string name="art_details_date_unknown">Date: Unknown</string>
+    <string name="art_details_no_description">No description available</string>
+    <string name="art_details_date_unknown">Unknown</string>
 </resources>

--- a/app/src/test/java/com/novack/art_gallery/art_details/domain/GetArtworkDetailsUseCaseTest.kt
+++ b/app/src/test/java/com/novack/art_gallery/art_details/domain/GetArtworkDetailsUseCaseTest.kt
@@ -1,0 +1,62 @@
+package com.novack.art_gallery.art_details.domain
+
+import com.novack.art_gallery.art_details.domain.models.ArtworkDetails
+import com.novack.art_gallery.common.data.ArtRepository
+import com.novack.art_gallery.common.domain.Logger
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+class GetArtworkDetailsUseCaseTest {
+
+    private val mockRepository: ArtRepository = mockk()
+    private val mockLogger: Logger = mockk() {
+        every { e(any(), any(), any()) } answers { println("Mocked error: ${args[1]}") }
+    }
+    private val getArtworkDetailsUseCase = GetArtworkDetailsUseCase(mockRepository, mockLogger)
+
+    @Test
+    fun `invoke() should emit Loading then Loaded on successful data fetch`() = runTest {
+        // Given
+        val fakeArtwork = ArtworkDetails(
+            id = "1",
+            title = "Artwork 1",
+            artist = "Artist 1",
+            imageUrl = "image1",
+            date = "1500",
+            description = "Description 1"
+        )
+        coEvery { mockRepository.getArtworkDetails(any()) } returns fakeArtwork
+
+        // When
+        val emissions = getArtworkDetailsUseCase("1").toList()
+
+        // Then
+        assertEquals(2, emissions.size)
+        assertTrue(emissions[0] is ArtworkDetailsState.Loading)
+        assertTrue(emissions[1] is ArtworkDetailsState.Loaded)
+        assertEquals(fakeArtwork, (emissions[1] as ArtworkDetailsState.Loaded).artworkDetails)
+    }
+
+    @Test
+    fun `invoke() should emit Loading then Error when repository throws exception`() = runTest {
+        // Given
+        val exception = IOException("Network Error")
+        coEvery { mockRepository.getArtworkDetails(any()) } throws exception
+
+        // When
+        val emissions = getArtworkDetailsUseCase("1").toList()
+
+        // Then
+        assertEquals(2, emissions.size)
+        assertTrue(emissions[0] is ArtworkDetailsState.Loading)
+        assertTrue(emissions[1] is ArtworkDetailsState.Error)
+    }
+
+}


### PR DESCRIPTION
Implemented Wiring for Art Details screen with the following features:
- Domain layer with `GetArtworkDetailsUseCase` and `ArtworkDetailsState` for managing data fetching and UI states.
- UI layer including `ArtworkDetailsViewModel` and `ArtDetailsScreen` composable.
- Navigation from Art Overview to Art Details screen.
- Mapper for `ArtworkDetailsState` to UI params.
- Updated `ArtworkDetailsDTO` to correctly map API response fields.
- Added unit tests for `GetArtworkDetailsUseCase`.
- Minor string resource updates.


https://github.com/user-attachments/assets/ca5befef-5d37-408e-ba99-4b6de7522888

